### PR TITLE
Build images for other db rotation functions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
-      - uses: jericop/buildpacks-github-actions/setup-tools@add-arm64-support
       - uses: docker/login-action@v2
         with:
           registry: ghcr.io
@@ -22,6 +21,8 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and Push Images to local registry
         run: |
+          set -x
+
           for registry_repo in $(cat images.json | jq -r '.push_to_repos | .[]'); do
             ./build-images.sh $registry_repo
           done

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and Push Images to local registry
+      - name: Build and push images
         run: |
           set -x
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,8 +10,6 @@ jobs:
       - uses: docker/setup-buildx-action@v2
       - name: Build and Push Images to local registry
         run: |
-          local_registry_port=5555
+          set -x
 
-          docker run -d -p $local_registry_port:5000 --rm --name registry registry:2
-
-          ./build-images.sh localhost:$local_registry_port/${{ github.repository }}
+          ./build-images.sh 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -8,7 +8,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
-      - name: Build and Push Images to local registry
+      - name: Build images
         run: |
           set -x
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,13 @@
 FROM public.ecr.aws/lambda/python:3.11
 
-ARG packages
+ARG system_packages
+ARG python_packages
 
-RUN yum update -y && yum install -y $packages
+# Install system package (if required). jq returns 'null' for keys not present
+RUN if [[ ! -z "$system_packages" && "$system_packages" != "null" ]]; then yum install -y $system_packages; fi
 
-# Copy requirements.txt
-COPY requirements.txt ${LAMBDA_TASK_ROOT}
-
-# Install the specified packages
-RUN pip install -r requirements.txt
+# Install python packages (if required). jq returns 'null' for keys not present
+RUN if [[ ! -z "$python_packages" && "$python_packages" != "null" ]]; then pip install $python_packages; fi
 
 # Copy function code
 COPY lambda_function.py ${LAMBDA_TASK_ROOT}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Secrets Manager provides rotation function templates for several types of credentials. To use the templates, see https://docs.aws.amazon.com/secretsmanager/latest/userguide/reference_available-rotation-templates.html.
 
+* This fork builds and publishes multi-arch container images as configured in `images.json`.
+* The repo(s) that the images are published to are specified in the `.push_to_repos` key.
+* Each image builds the folder and then pushes to the repo using the specified tag.
+
 ## License Summary
 
 This sample code is made available under a modified MIT license. See the LICENSE file.

--- a/SecretsManagerRDSMySQLRotationMultiUser/requirements.txt
+++ b/SecretsManagerRDSMySQLRotationMultiUser/requirements.txt
@@ -1,3 +1,0 @@
-# https://docs.aws.amazon.com/secretsmanager/latest/userguide/reference_available-rotation-templates.html#RDS_rotation_templates
-
-PyMySQL==1.0.2

--- a/SecretsManagerRDSMySQLRotationSingleUser/requirements.txt
+++ b/SecretsManagerRDSMySQLRotationSingleUser/requirements.txt
@@ -1,3 +1,0 @@
-# https://docs.aws.amazon.com/secretsmanager/latest/userguide/reference_available-rotation-templates.html#RDS_rotation_templates
-
-PyMySQL==1.0.2

--- a/SecretsManagerRDSPostgreSQLRotationMultiUser/requirements.txt
+++ b/SecretsManagerRDSPostgreSQLRotationMultiUser/requirements.txt
@@ -1,3 +1,0 @@
-# https://docs.aws.amazon.com/secretsmanager/latest/userguide/reference_available-rotation-templates.html#RDS_rotation_templates
-
-PyGreSQL==5.0.7

--- a/SecretsManagerRDSPostgreSQLRotationSingleUser/requirements.txt
+++ b/SecretsManagerRDSPostgreSQLRotationSingleUser/requirements.txt
@@ -1,3 +1,0 @@
-# https://docs.aws.amazon.com/secretsmanager/latest/userguide/reference_available-rotation-templates.html#RDS_rotation_templates
-
-PyGreSQL==5.0.7

--- a/build-images.sh
+++ b/build-images.sh
@@ -10,13 +10,15 @@ for row in $(cat images.json | jq -r '.folders[] | @base64'); do
   }
 
   folder=$(_jq '.folder')
-  packages=$(_jq '.required_packages')
+  system_packages=$(_jq '.install_system_packages') # returns 'null' if key is not present
+  python_packages=$(_jq '.python_packages')         # returns 'null' if key is not present
   tag=$(_jq '.tag')
   
   cp Dockerfile $folder
   
   docker buildx build \
-    --build-arg "packages=$packages" \
+    --build-arg "system_packages=$system_packages" \
+    --build-arg "python_packages=$python_packages" \
     --platform linux/amd64,linux/arm64 \
     --tag "$registry_repo:$tag" \
     --push  $folder 

--- a/build-images.sh
+++ b/build-images.sh
@@ -1,8 +1,16 @@
 #!/bin/bash
 
 set -euo pipefail
+set -x
 
-registry_repo="$1"
+registry_repo="${1:-ignored-not-pushed}"
+
+docker_push_arg="--push"
+
+# Remove push flag if registry_repo was not specified
+if [[ "$registry_repo" == "ignored-not-pushed" ]] ; then
+  docker_push_arg=""
+fi
 
 for row in $(cat images.json | jq -r '.folders[] | @base64'); do
   _jq() {
@@ -20,8 +28,8 @@ for row in $(cat images.json | jq -r '.folders[] | @base64'); do
     --build-arg "system_packages=$system_packages" \
     --build-arg "python_packages=$python_packages" \
     --platform linux/amd64,linux/arm64 \
-    --tag "$registry_repo:$tag" \
-    --push  $folder 
+    --tag "$registry_repo:$tag" $docker_push_arg \
+    $folder
   
   rm $folder/Dockerfile
   

--- a/images.json
+++ b/images.json
@@ -13,12 +13,12 @@
       "tag": "elasticache-single-user"
     },
     {
-      "folder": "SecretsManagerRDSMongoDBRotationSingleUser",
+      "folder": "SecretsManagerMongoDBRotationSingleUser",
       "python_packages": "Pymongo==3.2",
       "tag": "mongodb-single-user"
     },
     {
-      "folder": "SecretsManagerRDSMongoDBRotationMultiUser",
+      "folder": "SecretsManagerMongoDBRotationMultiUser",
       "python_packages": "Pymongo==3.2",
       "tag": "mongodb-multi-user"
     },

--- a/images.json
+++ b/images.json
@@ -5,24 +5,92 @@
   ],
   "folders": [
     {
-      "folder": "SecretsManagerRDSPostgreSQLRotationSingleUser",
-      "required_packages": "gcc postgresql postgresql-libs postgresql-devel",
-      "tag": "postgres-single-user"
+      "folder": "SecretsManagerActiveDirectoryRotationSingleUser",
+      "tag": "active-directory-single-user"
     },
     {
-      "folder": "SecretsManagerRDSPostgreSQLRotationMultiUser",
-      "required_packages": "gcc postgresql postgresql-libs postgresql-devel",
-      "tag": "postgres-multi-user"
+      "folder": "SecretsManagerElasticacheUserRotation",
+      "tag": "elasticache-single-user"
+    },
+    {
+      "folder": "SecretsManagerRDSMongoDBRotationSingleUser",
+      "python_packages": "Pymongo==3.2",
+      "tag": "mongodb-single-user"
+    },
+    {
+      "folder": "SecretsManagerRDSMongoDBRotationMultiUser",
+      "python_packages": "Pymongo==3.2",
+      "tag": "mongodb-multi-user"
+    },
+    {
+      "folder": "SecretsManagerRDSMariaDBRotationSingleUser",
+      "install_system_packages": "mariadb-libs",
+      "python_packages": "PyMySQL==1.0.2",
+      "tag": "mariadb-single-user"
+    },
+    {
+      "folder": "SecretsManagerRDSMariaDBRotationMultiUser",
+      "install_system_packages": "mariadb-libs",
+      "python_packages": "PyMySQL==1.0.2",
+      "tag": "mariadb-multi-user"
     },
     {
       "folder": "SecretsManagerRDSMySQLRotationSingleUser",
-      "required_packages": "mariadb-libs",
+      "install_system_packages": "mariadb-libs",
+      "python_packages": "PyMySQL==1.0.2",
       "tag": "mysql-single-user"
     },
     {
       "folder": "SecretsManagerRDSMySQLRotationMultiUser",
-      "required_packages": "mariadb-libs",
+      "install_system_packages": "mariadb-libs",
+      "python_packages": "PyMySQL==1.0.2",
       "tag": "mysql-multi-user"
+    },
+    {
+      "folder": "SecretsManagerRDSOracleRotationSingleUser",
+      "install_system_packages": "gcc",
+      "python_packages": "cx_Oracle==6.0.2",
+      "tag": "oracle-single-user"
+    },
+    {
+      "folder": "SecretsManagerRDSOracleRotationMultiUser",
+      "install_system_packages": "gcc",
+      "python_packages": "cx_Oracle==6.0.2",
+      "tag": "oracle-multi-user"
+    },
+    {
+      "folder": "SecretsManagerRDSPostgreSQLRotationSingleUser",
+      "install_system_packages": "gcc postgresql postgresql-libs postgresql-devel",
+      "python_packages": "PyGreSQL==5.0.7",
+      "tag": "postgres-single-user"
+    },
+    {
+      "folder": "SecretsManagerRDSPostgreSQLRotationMultiUser",
+      "install_system_packages": "gcc postgresql postgresql-libs postgresql-devel",
+      "python_packages": "PyGreSQL==5.0.7",
+      "tag": "postgres-multi-user"
+    },
+    {
+      "folder": "SecretsManagerRedshiftRotationSingleUser",
+      "install_system_packages": "gcc postgresql postgresql-libs postgresql-devel",
+      "python_packages": "PyGreSQL==5.0.7",
+      "tag": "redshift-single-user"
+    },
+    {
+      "folder": "SecretsManagerRedshiftRotationMultiUser",
+      "install_system_packages": "gcc postgresql postgresql-libs postgresql-devel",
+      "python_packages": "PyGreSQL==5.0.7",
+      "tag": "redshift-multi-user"
+    },
+    {
+      "folder": "SecretsManagerRDSSQLServerRotationSingleUser",
+      "python_packages": "Pymssql==2.2.2",
+      "tag": "sqlserver-single-user"
+    },
+    {
+      "folder": "SecretsManagerRDSSQLServerRotationMultiUser",
+      "python_packages": "Pymssql==2.2.2",
+      "tag": "sqlserver-multi-user"
     }
   ]
 }

--- a/images.json
+++ b/images.json
@@ -81,16 +81,6 @@
       "install_system_packages": "gcc postgresql postgresql-libs postgresql-devel",
       "python_packages": "PyGreSQL==5.0.7",
       "tag": "redshift-multi-user"
-    },
-    {
-      "folder": "SecretsManagerRDSSQLServerRotationSingleUser",
-      "python_packages": "Pymssql==2.2.2",
-      "tag": "sqlserver-single-user"
-    },
-    {
-      "folder": "SecretsManagerRDSSQLServerRotationMultiUser",
-      "python_packages": "Pymssql==2.2.2",
-      "tag": "sqlserver-multi-user"
     }
   ]
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* `requirements.txt` were removed in favor of `python_packages` key in `images.json`
* Update `Dockerfile` to make installation of system or python packages optional
* Update readme
* `sqlserver-*` images were removed because `freetds` is not available on `amazonlinux:2` , which is the base image used to create the lambda rotation function images.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
