### PR TITLE
Publish linux/amd64 images because lambda does not support multi-arch images

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -24,10 +24,9 @@ for row in $(cat images.json | jq -r '.folders[] | @base64'); do
   
   cp Dockerfile $folder
   
-  docker buildx build \
+  docker build \
     --build-arg "system_packages=$system_packages" \
     --build-arg "python_packages=$python_packages" \
-    --platform linux/amd64,linux/arm64 \
     --tag "$registry_repo:$tag" $docker_push_arg \
     $folder
   


### PR DESCRIPTION
*Issue #, if available:*

lambda does not support multi-arch images at this time.
https://repost.aws/questions/QUIZjd2sL_TtCuoqtg5Q30LA/does-lambda-not-support-multi-architecture-container-images-manifests

*Description of changes:*

This changes the build script to only publish `linux/amd64` images.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
